### PR TITLE
Add CSRF protection, HTML sanitization and secure admin actions for Le Mag

### DIFF
--- a/admin/le-mag/index.php
+++ b/admin/le-mag/index.php
@@ -74,12 +74,27 @@ $config = blog_config();
 $authors = $config['authors'];
 $error = '';
 $success = '';
+$editorNotice = '';
 $editPost = null;
 $linkedTestimonials = [];
 $allowedTabs = ['articles', 'create-post', 'create-testimonial', 'create-category'];
 $activeTab = (string)($_GET['tab'] ?? $_POST['tab'] ?? 'articles');
 if (!in_array($activeTab, $allowedTabs, true)) {
     $activeTab = 'articles';
+}
+
+if (!empty($_SESSION['melina_logout_error'])) {
+    $error = (string) $_SESSION['melina_logout_error'];
+    unset($_SESSION['melina_logout_error']);
+}
+
+$csrfRequestValid = true;
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
+    $csrfAction = (string) ($_POST['action'] ?? 'unknown');
+    $csrfRequestValid = blog_csrf_validate_request($csrfAction);
+    if (!$csrfRequestValid) {
+        $error = BLOG_CSRF_ERROR_MESSAGE;
+    }
 }
 
 try {
@@ -101,7 +116,7 @@ try {
     exit;
 }
 
-if (isset($_POST['action']) && $_POST['action'] === 'login') {
+if ($csrfRequestValid && isset($_POST['action']) && $_POST['action'] === 'login') {
     $username = trim((string)($_POST['username'] ?? ''));
     $password = (string)($_POST['password'] ?? '');
     if (!blog_try_login($username, $password)) {
@@ -117,12 +132,12 @@ if (!blog_is_admin()) {
     <!DOCTYPE html>
     <html lang="fr"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Connexion Le Mag</title>
       <style>body{font-family:Arial;background:#f8fafc;padding:1rem}.box{max-width:420px;margin:2rem auto;background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:1rem}input{width:100%;padding:.6rem;margin:.4rem 0;border:1px solid #d1d5db;border-radius:8px}.btn{background:#b42c2d;color:#fff;border:0;padding:.6rem .9rem;border-radius:999px;cursor:pointer}</style>
-    </head><body><main class="box"><h1>Admin Le Mag</h1><?php if ($error): ?><p style="color:#b91c1c"><?= blog_h($error) ?></p><?php endif; ?><form method="post"><input type="hidden" name="action" value="login"><label>Identifiant</label><input name="username" required><label>Mot de passe</label><input name="password" type="password" required><p><button class="btn" type="submit">Se connecter</button></p></form></main></body></html>
+    </head><body><main class="box"><h1>Admin Le Mag</h1><?php if ($error): ?><p style="color:#b91c1c"><?= blog_h($error) ?></p><?php endif; ?><form method="post"><input type="hidden" name="action" value="login"><input type="hidden" name="csrf_token" value="<?= blog_h(blog_csrf_token()) ?>"><label>Identifiant</label><input name="username" required><label>Mot de passe</label><input name="password" type="password" required><p><button class="btn" type="submit">Se connecter</button></p></form></main></body></html>
     <?php
     exit;
 }
 
-if (isset($_POST['action']) && $_POST['action'] === 'save_category') {
+if ($csrfRequestValid && isset($_POST['action']) && $_POST['action'] === 'save_category') {
     $activeTab = 'create-category';
     $id = blog_slugify((string)($_POST['id'] ?? ''));
     $name = trim((string)($_POST['name'] ?? ''));
@@ -134,7 +149,7 @@ if (isset($_POST['action']) && $_POST['action'] === 'save_category') {
     }
 }
 
-if (isset($_POST['action']) && $_POST['action'] === 'save_testimonial') {
+if ($csrfRequestValid && isset($_POST['action']) && $_POST['action'] === 'save_testimonial') {
     $activeTab = 'create-testimonial';
     $id = (int)($_POST['testimonial_id'] ?? 0);
     $data = [
@@ -156,9 +171,9 @@ if (isset($_POST['action']) && $_POST['action'] === 'save_testimonial') {
     $success = 'Témoignage enregistré.';
 }
 
-if (isset($_GET['delete_post'])) {
+if ($csrfRequestValid && isset($_POST['action']) && $_POST['action'] === 'delete_post') {
     $activeTab = 'articles';
-    $id = (int)$_GET['delete_post'];
+    $id = (int)($_POST['delete_post'] ?? 0);
     $postStmt = $pdo->prepare('SELECT testimonial_image_path FROM blog_posts WHERE id=:id LIMIT 1');
     $postStmt->execute(['id' => $id]);
     $postToDelete = $postStmt->fetch();
@@ -168,9 +183,9 @@ if (isset($_GET['delete_post'])) {
     $success = 'Article supprimé.';
 }
 
-if (isset($_GET['delete_testimonial'])) {
+if ($csrfRequestValid && isset($_POST['action']) && $_POST['action'] === 'delete_testimonial') {
     $activeTab = 'create-testimonial';
-    $id = (int)$_GET['delete_testimonial'];
+    $id = (int)($_POST['delete_testimonial'] ?? 0);
     $pdo->prepare('DELETE FROM blog_post_testimonials WHERE testimonial_id=:id')->execute(['id' => $id]);
     $pdo->prepare('DELETE FROM blog_testimonials WHERE id=:id')->execute(['id' => $id]);
     $success = 'Témoignage supprimé.';
@@ -179,20 +194,22 @@ if (isset($_GET['delete_testimonial'])) {
 $categories = blog_fetch_categories();
 $categoryIds = array_column($categories, 'id');
 
-if (isset($_POST['action']) && $_POST['action'] === 'save_post') {
+if ($csrfRequestValid && isset($_POST['action']) && $_POST['action'] === 'save_post') {
     $categoryId = trim((string)($_POST['category_id'] ?? ''));
     if (!in_array($categoryId, $categoryIds, true)) {
         $error = 'Catégorie invalide : veuillez choisir une catégorie disponible.';
     }
 }
 
-if ($error === '' && isset($_POST['action']) && $_POST['action'] === 'save_post') {
+if ($error === '' && $csrfRequestValid && isset($_POST['action']) && $_POST['action'] === 'save_post') {
     $activeTab = 'create-post';
     $id = (int)($_POST['post_id'] ?? 0);
     $title = trim((string)($_POST['title'] ?? ''));
     $slug = blog_slugify((string)($_POST['slug'] ?? $title));
     $excerpt = trim((string)($_POST['excerpt'] ?? ''));
     $content = (string)($_POST['content_html'] ?? '');
+    $contentWasSanitized = false;
+    $content = blog_sanitize_content_html($content, $contentWasSanitized);
     $categoryId = trim((string)($_POST['category_id'] ?? ''));
     $status = ($_POST['status'] ?? 'draft') === 'published' ? 'published' : 'draft';
     $author = in_array($_POST['author_name'] ?? '', $authors, true) ? $_POST['author_name'] : $authors[0];
@@ -343,6 +360,9 @@ if ($error === '' && isset($_POST['action']) && $_POST['action'] === 'save_post'
             }
 
             $success = 'Article enregistré.';
+            if ($contentWasSanitized) {
+                $editorNotice = 'Certaines balises ou attributs ont été supprimés pour des raisons de sécurité.';
+            }
         } else {
             $editPost = $editPost ?? [];
             $editPost['id'] = $id;
@@ -394,6 +414,7 @@ if (isset($_GET['edit_post'])) {
     table{width:100%;border-collapse:collapse}th,td{padding:.5rem;border-bottom:1px solid #e5e7eb;text-align:left;font-size:.92rem}
     .btn{background:#b42c2d;color:#fff;text-decoration:none;border:0;border-radius:999px;padding:.5rem .9rem;cursor:pointer;display:inline-block}
     .btn.alt{background:#fff;color:#b42c2d;border:1px solid #b42c2d}
+    .btn.linklike{background:none;border:0;color:#0f766e;padding:0;font:inherit;cursor:pointer;text-decoration:underline}
     .testi-tools{display:flex;gap:.55rem;align-items:center}
     .testi-search{flex:1}
     .testi-results{border:1px solid #d1d5db;border-radius:8px;max-height:180px;overflow:auto;background:#fff}
@@ -416,11 +437,15 @@ if (isset($_GET['edit_post'])) {
     <div><h1>Back-office Le Mag</h1><p class="meta">Articles, catégories et témoignages.</p></div>
     <div>
       <a class="btn alt" href="/le-mag/" target="_blank" rel="noopener">Voir Le Mag</a>
-      <a class="btn" href="/admin/le-mag/logout.php">Se déconnecter</a>
+      <form method="post" action="/admin/le-mag/logout.php" style="display:inline">
+        <input type="hidden" name="csrf_token" value="<?= blog_h(blog_csrf_token()) ?>">
+        <button class="btn" type="submit" onclick="return confirm('Voulez-vous vous déconnecter ?')">Se déconnecter</button>
+      </form>
     </div>
   </header>
 
   <?php if ($success): ?><p style="color:#166534"><?= blog_h($success) ?></p><?php endif; ?>
+  <?php if ($editorNotice): ?><p style="color:#1d4ed8"><?= blog_h($editorNotice) ?></p><?php endif; ?>
   <?php if ($error): ?><p style="color:#b91c1c"><?= blog_h($error) ?></p><?php endif; ?>
 
   <nav class="tabs" aria-label="Navigation du back-office Le Mag">
@@ -445,7 +470,13 @@ if (isset($_GET['edit_post'])) {
               <td><?= blog_h($p['author_name']) ?></td>
               <td>
                 <a href="?tab=create-post&edit_post=<?= (int)$p['id'] ?>">Modifier</a> |
-                <a href="?tab=articles&delete_post=<?= (int)$p['id'] ?>" onclick="return confirm('Supprimer cet article ?')">Supprimer</a>
+                <form method="post" style="display:inline">
+                  <input type="hidden" name="tab" value="articles">
+                  <input type="hidden" name="action" value="delete_post">
+                  <input type="hidden" name="delete_post" value="<?= (int)$p['id'] ?>">
+                  <input type="hidden" name="csrf_token" value="<?= blog_h(blog_csrf_token()) ?>">
+                  <button class="btn linklike" type="submit" onclick="return confirm('Supprimer cet article ?')">Supprimer</button>
+                </form>
               </td>
             </tr>
           <?php endforeach; ?>
@@ -460,6 +491,7 @@ if (isset($_GET['edit_post'])) {
         <form method="post" class="stack" enctype="multipart/form-data">
           <input type="hidden" name="tab" value="create-post">
           <input type="hidden" name="action" value="save_post">
+          <input type="hidden" name="csrf_token" value="<?= blog_h(blog_csrf_token()) ?>">
           <input type="hidden" name="post_id" value="<?= (int)($editPost['id'] ?? 0) ?>">
           <label>Titre</label><input name="title" required value="<?= blog_h((string)($editPost['title'] ?? '')) ?>">
           <label>Slug URL</label><input name="slug" value="<?= blog_h((string)($editPost['slug'] ?? '')) ?>">
@@ -483,6 +515,7 @@ if (isset($_GET['edit_post'])) {
           <label>Titre SEO</label><input name="seo_title" value="<?= blog_h((string)($editPost['seo_title'] ?? '')) ?>">
           <label>Meta description</label><textarea name="seo_description" rows="2"><?= blog_h((string)($editPost['seo_description'] ?? '')) ?></textarea>
           <label>Contenu de l'article (HTML simple)</label><textarea name="content_html" rows="10" required><?= blog_h((string)($editPost['content_html'] ?? '')) ?></textarea>
+          <p class="helper">Balises autorisées : p, h2, h3, ul, ol, li, strong, em, blockquote, a, br. Pour les liens, seuls les href en https, /chemin ou #ancre sont conservés.</p>
 
           <label>Image au-dessus du bloc Témoignage (horizontal)</label>
           <input type="file" name="testimonial_image" accept=".jpg,.jpeg,.png,.webp" id="testimonial-image-input">
@@ -550,6 +583,7 @@ if (isset($_GET['edit_post'])) {
         <form method="post" class="stack">
           <input type="hidden" name="tab" value="create-testimonial">
           <input type="hidden" name="action" value="save_testimonial">
+          <input type="hidden" name="csrf_token" value="<?= blog_h(blog_csrf_token()) ?>">
           <input type="hidden" name="testimonial_id" value="0">
           <label>Texte du témoignage</label><textarea name="quote_text" rows="4" required></textarea>
           <label>Nom affiché (anonyme ou prénom)</label><input name="person_name" required>
@@ -564,7 +598,20 @@ if (isset($_GET['edit_post'])) {
           <thead><tr><th>Nom</th><th>Statut</th><th>Autorisation</th><th></th></tr></thead>
           <tbody>
             <?php foreach ($testimonials as $t): ?>
-              <tr><td><?= blog_h($t['person_name']) ?></td><td><?= blog_h($t['status']) ?></td><td><?= (int)$t['consent_publication'] === 1 ? 'Oui' : 'Non' ?></td><td><a href="?tab=create-testimonial&delete_testimonial=<?= (int)$t['id'] ?>" onclick="return confirm('Supprimer ce témoignage ?')">Supprimer</a></td></tr>
+              <tr>
+                <td><?= blog_h($t['person_name']) ?></td>
+                <td><?= blog_h($t['status']) ?></td>
+                <td><?= (int)$t['consent_publication'] === 1 ? 'Oui' : 'Non' ?></td>
+                <td>
+                  <form method="post" style="display:inline">
+                    <input type="hidden" name="tab" value="create-testimonial">
+                    <input type="hidden" name="action" value="delete_testimonial">
+                    <input type="hidden" name="delete_testimonial" value="<?= (int)$t['id'] ?>">
+                    <input type="hidden" name="csrf_token" value="<?= blog_h(blog_csrf_token()) ?>">
+                    <button class="btn linklike" type="submit" onclick="return confirm('Supprimer ce témoignage ?')">Supprimer</button>
+                  </form>
+                </td>
+              </tr>
             <?php endforeach; ?>
           </tbody>
         </table>
@@ -577,6 +624,7 @@ if (isset($_GET['edit_post'])) {
         <form method="post" class="stack">
           <input type="hidden" name="tab" value="create-category">
           <input type="hidden" name="action" value="save_category">
+          <input type="hidden" name="csrf_token" value="<?= blog_h(blog_csrf_token()) ?>">
           <label>ID (slug)</label><input name="id" required placeholder="conseils-aux-familles">
           <label>Nom</label><input name="name" required>
           <label>Description</label><textarea name="description" rows="2"></textarea>

--- a/admin/le-mag/logout.php
+++ b/admin/le-mag/logout.php
@@ -1,5 +1,13 @@
 <?php
 require_once __DIR__ . '/../../blog-lib/auth.php';
+
+blog_start_session();
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST' || !blog_csrf_validate_request('logout')) {
+    $_SESSION['melina_logout_error'] = BLOG_CSRF_ERROR_MESSAGE;
+    header('Location: /admin/le-mag/index.php');
+    exit;
+}
+
 blog_logout();
 header('Location: /admin/le-mag/index.php');
 exit;

--- a/blog-lib/auth.php
+++ b/blog-lib/auth.php
@@ -6,6 +6,10 @@ require_once __DIR__ . '/db.php';
 
 const BLOG_ADMIN_SESSION_KEY = 'melina_admin';
 const BLOG_SESSION_NAME = 'melina_admin_session';
+const BLOG_CSRF_TOKEN_KEY = 'blog_csrf_token';
+const BLOG_CSRF_ISSUED_AT_KEY = 'blog_csrf_issued_at';
+const BLOG_CSRF_TTL_SECONDS = 7200;
+const BLOG_CSRF_ERROR_MESSAGE = 'Session expirée, merci de recharger la page.';
 
 function blog_start_session(): void
 {
@@ -88,4 +92,59 @@ function blog_logout(): void
     }
 
     session_destroy();
+}
+
+function blog_log_security_event(string $event, array $context = []): void
+{
+    $logDir = dirname(__DIR__) . '/logs';
+    if (!is_dir($logDir)) {
+        @mkdir($logDir, 0775, true);
+    }
+
+    $logFile = $logDir . '/security.log';
+    $payload = [
+        'time' => gmdate('c'),
+        'event' => $event,
+        'ip' => (string) ($_SERVER['REMOTE_ADDR'] ?? ''),
+        'ua' => (string) ($_SERVER['HTTP_USER_AGENT'] ?? ''),
+        'context' => $context,
+    ];
+
+    @file_put_contents($logFile, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . PHP_EOL, FILE_APPEND | LOCK_EX);
+}
+
+function blog_csrf_token(): string
+{
+    blog_start_session();
+
+    $token = (string) ($_SESSION[BLOG_CSRF_TOKEN_KEY] ?? '');
+    $issuedAt = (int) ($_SESSION[BLOG_CSRF_ISSUED_AT_KEY] ?? 0);
+    $isExpired = $issuedAt <= 0 || (time() - $issuedAt) >= BLOG_CSRF_TTL_SECONDS;
+
+    if ($token === '' || $isExpired) {
+        $token = bin2hex(random_bytes(32));
+        $_SESSION[BLOG_CSRF_TOKEN_KEY] = $token;
+        $_SESSION[BLOG_CSRF_ISSUED_AT_KEY] = time();
+    }
+
+    return $token;
+}
+
+function blog_csrf_validate_request(string $action): bool
+{
+    blog_start_session();
+    blog_csrf_token();
+
+    $candidate = (string) ($_POST['csrf_token'] ?? '');
+    $sessionToken = (string) ($_SESSION[BLOG_CSRF_TOKEN_KEY] ?? '');
+    if ($candidate === '' || $sessionToken === '' || !hash_equals($sessionToken, $candidate)) {
+        blog_log_security_event('csrf_validation_failed', [
+            'action' => $action,
+            'method' => (string) ($_SERVER['REQUEST_METHOD'] ?? ''),
+            'uri' => (string) ($_SERVER['REQUEST_URI'] ?? ''),
+        ]);
+        return false;
+    }
+
+    return true;
 }

--- a/blog-lib/utils.php
+++ b/blog-lib/utils.php
@@ -54,3 +54,132 @@ function blog_fetch_categories(): array
     $stmt = blog_pdo()->query('SELECT id, name, description, sort_order FROM blog_categories ORDER BY sort_order ASC, name ASC');
     return $stmt->fetchAll();
 }
+
+function blog_is_allowed_href(string $href): bool
+{
+    $href = trim($href);
+    if ($href === '') {
+        return false;
+    }
+
+    if (str_starts_with($href, '/')) {
+        return true;
+    }
+
+    if (str_starts_with($href, '#')) {
+        return true;
+    }
+
+    return preg_match('/^https:\/\/[^\s]+$/iu', $href) === 1;
+}
+
+function blog_sanitize_content_html(string $html, ?bool &$wasModified = null): string
+{
+    $allowedTags = ['p', 'h2', 'h3', 'ul', 'ol', 'li', 'strong', 'em', 'blockquote', 'a', 'br'];
+    $wasModified = false;
+
+    $wrappedHtml = '<div id="blog-sanitizer-root">' . $html . '</div>';
+
+    libxml_use_internal_errors(true);
+    $dom = new DOMDocument('1.0', 'UTF-8');
+    $loaded = $dom->loadHTML(
+        '<?xml encoding="UTF-8">' . $wrappedHtml,
+        LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+    );
+    libxml_clear_errors();
+
+    if (!$loaded) {
+        $wasModified = true;
+        return '';
+    }
+
+    $xpath = new DOMXPath($dom);
+    $root = $xpath->query('//*[@id="blog-sanitizer-root"]')->item(0);
+    if (!$root instanceof DOMElement) {
+        $wasModified = true;
+        return '';
+    }
+
+    $sanitizeNode = static function (DOMNode $node) use (&$sanitizeNode, $dom, $allowedTags, &$wasModified): void {
+        if ($node instanceof DOMElement) {
+            $tagName = strtolower($node->tagName);
+
+            if (!in_array($tagName, $allowedTags, true)) {
+                $wasModified = true;
+
+                if (in_array($tagName, ['script', 'style', 'iframe'], true)) {
+                    $node->parentNode?->removeChild($node);
+                    return;
+                }
+
+                while ($node->firstChild) {
+                    $node->parentNode?->insertBefore($node->firstChild, $node);
+                }
+                $node->parentNode?->removeChild($node);
+                return;
+            }
+
+            $allowedAttributes = $tagName === 'a' ? ['href', 'target', 'rel'] : [];
+            $attributes = [];
+            foreach ($node->attributes ?? [] as $attribute) {
+                $attributes[] = $attribute;
+            }
+
+            foreach ($attributes as $attribute) {
+                $name = strtolower($attribute->name);
+                if (!in_array($name, $allowedAttributes, true)) {
+                    $node->removeAttributeNode($attribute);
+                    $wasModified = true;
+                }
+            }
+
+            if ($tagName === 'a') {
+                $href = (string) $node->getAttribute('href');
+                if (!blog_is_allowed_href($href)) {
+                    while ($node->firstChild) {
+                        $node->parentNode?->insertBefore($node->firstChild, $node);
+                    }
+                    $node->parentNode?->removeChild($node);
+                    $wasModified = true;
+                    return;
+                }
+
+                $target = strtolower((string) $node->getAttribute('target'));
+                if ($target !== '_blank') {
+                    if ($target !== '') {
+                        $wasModified = true;
+                    }
+                    $node->removeAttribute('target');
+                    $node->removeAttribute('rel');
+                } else {
+                    $node->setAttribute('target', '_blank');
+                    $node->setAttribute('rel', 'noopener noreferrer');
+                }
+            }
+        }
+
+        $children = [];
+        foreach ($node->childNodes as $child) {
+            $children[] = $child;
+        }
+
+        foreach ($children as $child) {
+            $sanitizeNode($child);
+        }
+    };
+
+    $rootChildren = [];
+    foreach ($root->childNodes as $child) {
+        $rootChildren[] = $child;
+    }
+    foreach ($rootChildren as $child) {
+        $sanitizeNode($child);
+    }
+
+    $result = '';
+    foreach ($root->childNodes as $child) {
+        $result .= $dom->saveHTML($child);
+    }
+
+    return trim($result);
+}

--- a/le-mag/article.php
+++ b/le-mag/article.php
@@ -37,6 +37,7 @@ try {
 }
 
 $cta = blog_cta_data($post['cta_variant'] ?? 'contact');
+$safeContentHtml = blog_sanitize_content_html((string) ($post['content_html'] ?? ''));
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -117,7 +118,7 @@ $cta = blog_cta_data($post['cta_variant'] ?? 'contact');
     <p><?= blog_h($post['category_name']) ?></p>
     <h1><?= blog_h($post['title']) ?></h1>
     <p class="meta"><?= blog_h(date('d/m/Y', strtotime((string)$post['published_at']))) ?> · <?= blog_h($post['author_name']) ?></p>
-    <div class="content"><?= $post['content_html'] ?></div>
+    <div class="content"><?= $safeContentHtml ?></div>
   </article>
 
   <?php if (!empty($post['testimonial_image_path'])): ?>


### PR DESCRIPTION
### Motivation
- Implement server-side CSRF protection for all admin POST actions and logout, and prevent destructive GET actions to harden the back-office against CSRF and accidental deletes. 
- Sanitize stored article HTML and restrict allowed link targets to avoid XSS and unsafe links when rendering articles. 
- Add basic security logging for CSRF validation failures and provide user-visible notices when editor content is modified by the sanitizer.

### Description
- Introduces CSRF support in `blog-lib/auth.php` with `blog_csrf_token()`, `blog_csrf_validate_request()`, CSRF-related constants and `blog_log_security_event()` for logging validation failures. 
- Requires CSRF validation in `admin/le-mag/index.php` for `login`, `save_category`, `save_testimonial`, `save_post`, `delete_post` and `delete_testimonial` actions, and adds hidden `csrf_token` inputs to admin forms and the login form. 
- Converts destructive GET links into POST forms for delete actions (articles and testimonials) and changes logout to accept only POST in `admin/le-mag/logout.php`, setting a session error on CSRF failure and displaying it on the admin index. 
- Adds HTML sanitizer `blog_sanitize_content_html()` and `blog_is_allowed_href()` to `blog-lib/utils.php`, enforces sanitization when saving post content and when rendering public article pages (`le-mag/article.php`), and sets an editor notice (`$editorNotice`) when content was modified. 
- Minor UI and UX updates: helper text listing allowed tags, style `.btn.linklike`, image preview/alt handling preserved, and session-based logout error display.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db78a1d74883329d326fbded30e663)