### PR TITLE
Add CSRF protection, HTML sanitization, WYSIWYG editor and security logging

### DIFF
--- a/admin/le-mag/index.php
+++ b/admin/le-mag/index.php
@@ -74,12 +74,27 @@ $config = blog_config();
 $authors = $config['authors'];
 $error = '';
 $success = '';
+$editorNotice = '';
 $editPost = null;
 $linkedTestimonials = [];
 $allowedTabs = ['articles', 'create-post', 'create-testimonial', 'create-category'];
 $activeTab = (string)($_GET['tab'] ?? $_POST['tab'] ?? 'articles');
 if (!in_array($activeTab, $allowedTabs, true)) {
     $activeTab = 'articles';
+}
+
+if (!empty($_SESSION['melina_logout_error'])) {
+    $error = (string) $_SESSION['melina_logout_error'];
+    unset($_SESSION['melina_logout_error']);
+}
+
+$csrfRequestValid = true;
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
+    $csrfAction = (string) ($_POST['action'] ?? 'unknown');
+    $csrfRequestValid = blog_csrf_validate_request($csrfAction);
+    if (!$csrfRequestValid) {
+        $error = BLOG_CSRF_ERROR_MESSAGE;
+    }
 }
 
 try {
@@ -101,7 +116,7 @@ try {
     exit;
 }
 
-if (isset($_POST['action']) && $_POST['action'] === 'login') {
+if ($csrfRequestValid && isset($_POST['action']) && $_POST['action'] === 'login') {
     $username = trim((string)($_POST['username'] ?? ''));
     $password = (string)($_POST['password'] ?? '');
     if (!blog_try_login($username, $password)) {
@@ -117,12 +132,12 @@ if (!blog_is_admin()) {
     <!DOCTYPE html>
     <html lang="fr"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Connexion Le Mag</title>
       <style>body{font-family:Arial;background:#f8fafc;padding:1rem}.box{max-width:420px;margin:2rem auto;background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:1rem}input{width:100%;padding:.6rem;margin:.4rem 0;border:1px solid #d1d5db;border-radius:8px}.btn{background:#b42c2d;color:#fff;border:0;padding:.6rem .9rem;border-radius:999px;cursor:pointer}</style>
-    </head><body><main class="box"><h1>Admin Le Mag</h1><?php if ($error): ?><p style="color:#b91c1c"><?= blog_h($error) ?></p><?php endif; ?><form method="post"><input type="hidden" name="action" value="login"><label>Identifiant</label><input name="username" required><label>Mot de passe</label><input name="password" type="password" required><p><button class="btn" type="submit">Se connecter</button></p></form></main></body></html>
+    </head><body><main class="box"><h1>Admin Le Mag</h1><?php if ($error): ?><p style="color:#b91c1c"><?= blog_h($error) ?></p><?php endif; ?><form method="post"><input type="hidden" name="action" value="login"><input type="hidden" name="csrf_token" value="<?= blog_h(blog_csrf_token()) ?>"><label>Identifiant</label><input name="username" required><label>Mot de passe</label><input name="password" type="password" required><p><button class="btn" type="submit">Se connecter</button></p></form></main></body></html>
     <?php
     exit;
 }
 
-if (isset($_POST['action']) && $_POST['action'] === 'save_category') {
+if ($csrfRequestValid && isset($_POST['action']) && $_POST['action'] === 'save_category') {
     $activeTab = 'create-category';
     $id = blog_slugify((string)($_POST['id'] ?? ''));
     $name = trim((string)($_POST['name'] ?? ''));
@@ -134,7 +149,7 @@ if (isset($_POST['action']) && $_POST['action'] === 'save_category') {
     }
 }
 
-if (isset($_POST['action']) && $_POST['action'] === 'save_testimonial') {
+if ($csrfRequestValid && isset($_POST['action']) && $_POST['action'] === 'save_testimonial') {
     $activeTab = 'create-testimonial';
     $id = (int)($_POST['testimonial_id'] ?? 0);
     $data = [
@@ -143,22 +158,23 @@ if (isset($_POST['action']) && $_POST['action'] === 'save_testimonial') {
         'person_role' => trim((string)($_POST['person_role'] ?? '')),
         'area_label' => trim((string)($_POST['area_label'] ?? '')),
         'status' => ($_POST['status'] ?? 'draft') === 'published' ? 'published' : 'draft',
+        'status_publish' => ($_POST['status'] ?? 'draft') === 'published' ? 'published' : 'draft',
         'consent_publication' => isset($_POST['consent_publication']) ? 1 : 0,
     ];
 
     if ($id > 0) {
-        $stmt = $pdo->prepare("UPDATE blog_testimonials SET quote_text=:quote_text, person_name=:person_name, person_role=:person_role, area_label=:area_label, status=:status, consent_publication=:consent_publication, published_at=IF(:status='published', NOW(), published_at), updated_at=NOW() WHERE id=:id");
+        $stmt = $pdo->prepare("UPDATE blog_testimonials SET quote_text=:quote_text, person_name=:person_name, person_role=:person_role, area_label=:area_label, status=:status, consent_publication=:consent_publication, published_at=IF(:status_publish='published', NOW(), published_at), updated_at=NOW() WHERE id=:id");
         $stmt->execute($data + ['id' => $id]);
     } else {
-        $stmt = $pdo->prepare("INSERT INTO blog_testimonials (quote_text, person_name, person_role, area_label, status, consent_publication, published_at, created_at, updated_at) VALUES (:quote_text,:person_name,:person_role,:area_label,:status,:consent_publication,IF(:status='published',NOW(),NULL),NOW(),NOW())");
+        $stmt = $pdo->prepare("INSERT INTO blog_testimonials (quote_text, person_name, person_role, area_label, status, consent_publication, published_at, created_at, updated_at) VALUES (:quote_text,:person_name,:person_role,:area_label,:status,:consent_publication,IF(:status_publish='published',NOW(),NULL),NOW(),NOW())");
         $stmt->execute($data);
     }
     $success = 'Témoignage enregistré.';
 }
 
-if (isset($_GET['delete_post'])) {
+if ($csrfRequestValid && isset($_POST['action']) && $_POST['action'] === 'delete_post') {
     $activeTab = 'articles';
-    $id = (int)$_GET['delete_post'];
+    $id = (int)($_POST['delete_post'] ?? 0);
     $postStmt = $pdo->prepare('SELECT testimonial_image_path FROM blog_posts WHERE id=:id LIMIT 1');
     $postStmt->execute(['id' => $id]);
     $postToDelete = $postStmt->fetch();
@@ -168,9 +184,9 @@ if (isset($_GET['delete_post'])) {
     $success = 'Article supprimé.';
 }
 
-if (isset($_GET['delete_testimonial'])) {
+if ($csrfRequestValid && isset($_POST['action']) && $_POST['action'] === 'delete_testimonial') {
     $activeTab = 'create-testimonial';
-    $id = (int)$_GET['delete_testimonial'];
+    $id = (int)($_POST['delete_testimonial'] ?? 0);
     $pdo->prepare('DELETE FROM blog_post_testimonials WHERE testimonial_id=:id')->execute(['id' => $id]);
     $pdo->prepare('DELETE FROM blog_testimonials WHERE id=:id')->execute(['id' => $id]);
     $success = 'Témoignage supprimé.';
@@ -179,20 +195,22 @@ if (isset($_GET['delete_testimonial'])) {
 $categories = blog_fetch_categories();
 $categoryIds = array_column($categories, 'id');
 
-if (isset($_POST['action']) && $_POST['action'] === 'save_post') {
+if ($csrfRequestValid && isset($_POST['action']) && $_POST['action'] === 'save_post') {
     $categoryId = trim((string)($_POST['category_id'] ?? ''));
     if (!in_array($categoryId, $categoryIds, true)) {
         $error = 'Catégorie invalide : veuillez choisir une catégorie disponible.';
     }
 }
 
-if ($error === '' && isset($_POST['action']) && $_POST['action'] === 'save_post') {
+if ($error === '' && $csrfRequestValid && isset($_POST['action']) && $_POST['action'] === 'save_post') {
     $activeTab = 'create-post';
     $id = (int)($_POST['post_id'] ?? 0);
     $title = trim((string)($_POST['title'] ?? ''));
     $slug = blog_slugify((string)($_POST['slug'] ?? $title));
     $excerpt = trim((string)($_POST['excerpt'] ?? ''));
     $content = (string)($_POST['content_html'] ?? '');
+    $contentWasSanitized = false;
+    $content = blog_sanitize_content_html($content, $contentWasSanitized);
     $categoryId = trim((string)($_POST['category_id'] ?? ''));
     $status = ($_POST['status'] ?? 'draft') === 'published' ? 'published' : 'draft';
     $author = in_array($_POST['author_name'] ?? '', $authors, true) ? $_POST['author_name'] : $authors[0];
@@ -300,6 +318,7 @@ if ($error === '' && isset($_POST['action']) && $_POST['action'] === 'save_post'
             'content_html' => $content,
             'category_id' => $categoryId,
             'status' => $status,
+            'status_publish' => $status,
             'author_name' => $author,
             'seo_title' => $seoTitle,
             'seo_description' => $seoDescription,
@@ -311,17 +330,47 @@ if ($error === '' && isset($_POST['action']) && $_POST['action'] === 'save_post'
         $saved = false;
         try {
             if ($id > 0) {
-                $stmt = $pdo->prepare("UPDATE blog_posts SET title=:title, slug=:slug, excerpt=:excerpt, content_html=:content_html, category_id=:category_id, status=:status, author_name=:author_name, seo_title=:seo_title, seo_description=:seo_description, cta_variant=:cta_variant, testimonial_image_path=:testimonial_image_path, testimonial_image_alt=:testimonial_image_alt, published_at=IF(:status='published' AND published_at IS NULL, NOW(), published_at), updated_at=NOW() WHERE id=:id");
+                $stmt = $pdo->prepare("UPDATE blog_posts SET title=:title, slug=:slug, excerpt=:excerpt, content_html=:content_html, category_id=:category_id, status=:status, author_name=:author_name, seo_title=:seo_title, seo_description=:seo_description, cta_variant=:cta_variant, testimonial_image_path=:testimonial_image_path, testimonial_image_alt=:testimonial_image_alt, published_at=IF(:status_publish='published' AND published_at IS NULL, NOW(), published_at), updated_at=NOW() WHERE id=:id");
                 $stmt->execute($payload + ['id' => $id]);
             } else {
-                $stmt = $pdo->prepare("INSERT INTO blog_posts (title, slug, excerpt, content_html, category_id, status, author_name, seo_title, seo_description, cta_variant, testimonial_image_path, testimonial_image_alt, published_at, created_at, updated_at) VALUES (:title,:slug,:excerpt,:content_html,:category_id,:status,:author_name,:seo_title,:seo_description,:cta_variant,:testimonial_image_path,:testimonial_image_alt,IF(:status='published',NOW(),NULL),NOW(),NOW())");
+                $stmt = $pdo->prepare("INSERT INTO blog_posts (title, slug, excerpt, content_html, category_id, status, author_name, seo_title, seo_description, cta_variant, testimonial_image_path, testimonial_image_alt, published_at, created_at, updated_at) VALUES (:title,:slug,:excerpt,:content_html,:category_id,:status,:author_name,:seo_title,:seo_description,:cta_variant,:testimonial_image_path,:testimonial_image_alt,IF(:status_publish='published',NOW(),NULL),NOW(),NOW())");
                 $stmt->execute($payload);
                 $id = (int)$pdo->lastInsertId();
             }
             $saved = true;
         } catch (PDOException $e) {
-            if (($e->getCode() === '23000') && str_contains(strtolower($e->getMessage()), 'slug')) {
+            $sqlState = (string) $e->getCode();
+            $errorMessage = strtolower($e->getMessage());
+            blog_log_security_event('blog_post_save_failed', [
+                'action' => $id > 0 ? 'update_post' : 'insert_post',
+                'post_id' => $id > 0 ? $id : null,
+                'sqlstate' => $sqlState,
+                'error_message' => $e->getMessage(),
+                'slug' => $slug,
+                'category_id' => $categoryId,
+            ]);
+
+            if (($sqlState === '23000') && str_contains($errorMessage, 'slug')) {
                 $error = 'Ce slug est déjà utilisé. Merci de choisir un slug unique.';
+            } elseif (($sqlState === '23000') && (str_contains($errorMessage, 'fk_blog_posts_category') || str_contains($errorMessage, 'category_id') || str_contains($errorMessage, 'foreign key'))) {
+                $error = 'Catégorie invalide ou supprimée. Merci de choisir une catégorie existante.';
+            } elseif ($sqlState === '22001' || str_contains($errorMessage, 'data too long')) {
+                $fieldLabel = 'Un champ texte';
+                if (preg_match("/for column '([^']+)'/i", $e->getMessage(), $matches) === 1) {
+                    $column = strtolower((string)($matches[1] ?? ''));
+                    $fieldMap = [
+                        'title' => 'Titre',
+                        'slug' => 'Slug URL',
+                        'author_name' => 'Auteur',
+                        'seo_title' => 'Titre SEO',
+                        'testimonial_image_alt' => 'Texte alternatif de l’image',
+                        'testimonial_image_path' => 'Nom de fichier image',
+                    ];
+                    if (isset($fieldMap[$column])) {
+                        $fieldLabel = $fieldMap[$column];
+                    }
+                }
+                $error = $fieldLabel . ' est trop long. Merci de raccourcir puis réessayer.';
             } else {
                 $error = 'Erreur lors de l’enregistrement de l’article. Merci de réessayer.';
             }
@@ -343,6 +392,9 @@ if ($error === '' && isset($_POST['action']) && $_POST['action'] === 'save_post'
             }
 
             $success = 'Article enregistré.';
+            if ($contentWasSanitized) {
+                $editorNotice = 'Certaines balises ou attributs ont été supprimés pour des raisons de sécurité.';
+            }
         } else {
             $editPost = $editPost ?? [];
             $editPost['id'] = $id;
@@ -394,6 +446,7 @@ if (isset($_GET['edit_post'])) {
     table{width:100%;border-collapse:collapse}th,td{padding:.5rem;border-bottom:1px solid #e5e7eb;text-align:left;font-size:.92rem}
     .btn{background:#b42c2d;color:#fff;text-decoration:none;border:0;border-radius:999px;padding:.5rem .9rem;cursor:pointer;display:inline-block}
     .btn.alt{background:#fff;color:#b42c2d;border:1px solid #b42c2d}
+    .btn.linklike{background:none;border:0;color:#0f766e;padding:0;font:inherit;cursor:pointer;text-decoration:underline}
     .testi-tools{display:flex;gap:.55rem;align-items:center}
     .testi-search{flex:1}
     .testi-results{border:1px solid #d1d5db;border-radius:8px;max-height:180px;overflow:auto;background:#fff}
@@ -407,6 +460,17 @@ if (isset($_GET['edit_post'])) {
     .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
     .helper{font-size:.85rem;color:#6b7280}
     .meta{font-size:.86rem;color:#6b7280}
+    .form-section{background:#f9fafb;border:1px solid #e5e7eb;border-radius:12px;padding:1rem}
+    .form-section + .form-section{margin-top:.5rem}
+    .form-section h3{margin:0 0 .75rem 0;font-size:1.02rem;color:#fff;background:#b42c2d;border-radius:999px;padding:.45rem .85rem;display:inline-block;transition:background .2s ease,transform .2s ease,box-shadow .2s ease}
+    .form-section:hover h3{background:#8f2223;transform:translateY(-1px);box-shadow:0 4px 10px rgba(180,44,45,.2)}
+    .form-footer{margin-top:.6rem}
+    .wysiwyg-wrap{border:1px solid #d1d5db;border-radius:10px;overflow:hidden;background:#fff}
+    .wysiwyg-toolbar{display:flex;flex-wrap:wrap;gap:.35rem;padding:.55rem;border-bottom:1px solid #e5e7eb;background:#f9fafb}
+    .wysiwyg-toolbar button{border:1px solid #d1d5db;background:#fff;border-radius:8px;padding:.35rem .55rem;cursor:pointer}
+    .wysiwyg-toolbar button:hover{border-color:#b42c2d;color:#b42c2d}
+    .wysiwyg-editor{min-height:220px;padding:.7rem;line-height:1.7;outline:none}
+    .wysiwyg-editor:empty:before{content:attr(data-placeholder);color:#9ca3af}
     @media (max-width: 980px){.grid{grid-template-columns:1fr}}
   </style>
 </head>
@@ -416,11 +480,15 @@ if (isset($_GET['edit_post'])) {
     <div><h1>Back-office Le Mag</h1><p class="meta">Articles, catégories et témoignages.</p></div>
     <div>
       <a class="btn alt" href="/le-mag/" target="_blank" rel="noopener">Voir Le Mag</a>
-      <a class="btn" href="/admin/le-mag/logout.php">Se déconnecter</a>
+      <form method="post" action="/admin/le-mag/logout.php" style="display:inline">
+        <input type="hidden" name="csrf_token" value="<?= blog_h(blog_csrf_token()) ?>">
+        <button class="btn" type="submit" onclick="return confirm('Voulez-vous vous déconnecter ?')">Se déconnecter</button>
+      </form>
     </div>
   </header>
 
   <?php if ($success): ?><p style="color:#166534"><?= blog_h($success) ?></p><?php endif; ?>
+  <?php if ($editorNotice): ?><p style="color:#1d4ed8"><?= blog_h($editorNotice) ?></p><?php endif; ?>
   <?php if ($error): ?><p style="color:#b91c1c"><?= blog_h($error) ?></p><?php endif; ?>
 
   <nav class="tabs" aria-label="Navigation du back-office Le Mag">
@@ -445,7 +513,13 @@ if (isset($_GET['edit_post'])) {
               <td><?= blog_h($p['author_name']) ?></td>
               <td>
                 <a href="?tab=create-post&edit_post=<?= (int)$p['id'] ?>">Modifier</a> |
-                <a href="?tab=articles&delete_post=<?= (int)$p['id'] ?>" onclick="return confirm('Supprimer cet article ?')">Supprimer</a>
+                <form method="post" style="display:inline">
+                  <input type="hidden" name="tab" value="articles">
+                  <input type="hidden" name="action" value="delete_post">
+                  <input type="hidden" name="delete_post" value="<?= (int)$p['id'] ?>">
+                  <input type="hidden" name="csrf_token" value="<?= blog_h(blog_csrf_token()) ?>">
+                  <button class="btn linklike" type="submit" onclick="return confirm('Supprimer cet article ?')">Supprimer</button>
+                </form>
               </td>
             </tr>
           <?php endforeach; ?>
@@ -460,86 +534,115 @@ if (isset($_GET['edit_post'])) {
         <form method="post" class="stack" enctype="multipart/form-data">
           <input type="hidden" name="tab" value="create-post">
           <input type="hidden" name="action" value="save_post">
+          <input type="hidden" name="csrf_token" value="<?= blog_h(blog_csrf_token()) ?>">
           <input type="hidden" name="post_id" value="<?= (int)($editPost['id'] ?? 0) ?>">
-          <label>Titre</label><input name="title" required value="<?= blog_h((string)($editPost['title'] ?? '')) ?>">
-          <label>Slug URL</label><input name="slug" value="<?= blog_h((string)($editPost['slug'] ?? '')) ?>">
-          <label>Extrait</label><textarea name="excerpt" rows="2" required><?= blog_h((string)($editPost['excerpt'] ?? '')) ?></textarea>
-          <label>Catégorie</label>
-          <select name="category_id" required>
-            <?php foreach ($categories as $c): ?>
-              <option value="<?= blog_h($c['id']) ?>" <?= (($editPost['category_id'] ?? '') === $c['id']) ? 'selected' : '' ?>><?= blog_h($c['name']) ?></option>
-            <?php endforeach; ?>
-          </select>
-          <label>Auteur</label>
-          <select name="author_name" required>
-            <?php foreach ($authors as $author): ?>
-              <option value="<?= blog_h($author) ?>" <?= (($editPost['author_name'] ?? '') === $author) ? 'selected' : '' ?>><?= blog_h($author) ?></option>
-            <?php endforeach; ?>
-          </select>
-          <label>Statut</label>
-          <select name="status"><option value="draft" <?= (($editPost['status'] ?? '') === 'draft') ? 'selected' : '' ?>>Brouillon</option><option value="published" <?= (($editPost['status'] ?? '') === 'published') ? 'selected' : '' ?>>Publié</option></select>
-          <label>Type de CTA</label>
-          <select name="cta_variant"><option value="contact" <?= (($editPost['cta_variant'] ?? '') === 'contact') ? 'selected' : '' ?>>Prendre contact</option><option value="visit" <?= (($editPost['cta_variant'] ?? '') === 'visit') ? 'selected' : '' ?>>Demander une visite</option></select>
-          <label>Titre SEO</label><input name="seo_title" value="<?= blog_h((string)($editPost['seo_title'] ?? '')) ?>">
-          <label>Meta description</label><textarea name="seo_description" rows="2"><?= blog_h((string)($editPost['seo_description'] ?? '')) ?></textarea>
-          <label>Contenu de l'article (HTML simple)</label><textarea name="content_html" rows="10" required><?= blog_h((string)($editPost['content_html'] ?? '')) ?></textarea>
-
-          <label>Image au-dessus du bloc Témoignage (horizontal)</label>
-          <input type="file" name="testimonial_image" accept=".jpg,.jpeg,.png,.webp" id="testimonial-image-input">
-          <p class="helper">Image horizontale recommandée (ex: 1600x900) pour un rendu optimal. Formats autorisés : JPG, JPEG, PNG, WEBP. Taille max 5 Mo. Exemple de nom SEO : colocation-senior-salon.webp</p>
-          <?php if (!empty($editPost['testimonial_image_path'])): ?>
-            <img
-              id="testimonial-image-preview"
-              src="<?= blog_h(blog_testimonial_image_url((string)$editPost['testimonial_image_path'])) ?>"
-              alt="<?= blog_h((string)($editPost['testimonial_image_alt'] ?? '')) ?>"
-              style="max-width:100%;height:140px;object-fit:cover;border-radius:10px;border:1px solid #d1d5db"
-            >
-            <label><input type="checkbox" name="remove_testimonial_image" value="1" id="remove-testimonial-image"> Supprimer l'image actuelle</label>
-          <?php else: ?>
-            <img id="testimonial-image-preview" src="" alt="" style="display:none;max-width:100%;height:140px;object-fit:cover;border-radius:10px;border:1px solid #d1d5db">
-          <?php endif; ?>
-
-          <label>Texte alternatif de l’image (obligatoire si image)</label>
-          <input
-            name="testimonial_image_alt"
-            value="<?= blog_h((string)($editPost['testimonial_image_alt'] ?? '')) ?>"
-            placeholder="Ex : Résidents lisant dans le salon de la colocation senior à Lyon"
-          >
-          <p class="helper">Alt descriptif recommandé (10 à 90 caractères), cohérent avec le sujet de l’article. Évitez les formulations génériques comme “photo proposée”.</p>
-
-          <label>Témoignage(s) lié(s)</label>
-          <div class="testi-tools">
-            <input type="search" id="testimonial-search" class="testi-search" placeholder="Rechercher par nom ou ID...">
-            <button class="btn alt" type="button" id="clear-testimonials">Tout désélectionner</button>
-          </div>
-          <p class="helper">Sélectionnez un ou plusieurs témoignages. Laissez vide si vous ne souhaitez en lier aucun.</p>
-          <div class="testi-selected" id="testimonial-selected"></div>
-          <div class="testi-results" id="testimonial-results">
-            <?php foreach ($testimonials as $t): ?>
-              <div
-                class="testi-row"
-                data-testid="<?= (int)$t['id'] ?>"
-                data-testi-label="<?= blog_h(mb_strtolower((string)$t['person_name'])) ?>"
-              >
-                <span>#<?= (int)$t['id'] ?> - <?= blog_h($t['person_name']) ?> (<?= blog_h($t['status']) ?>)</span>
-                <button type="button" data-toggle-testimonial="<?= (int)$t['id'] ?>" class="<?= in_array((int)$t['id'], $linkedTestimonials, true) ? 'active' : '' ?>">
-                  <?= in_array((int)$t['id'], $linkedTestimonials, true) ? 'Sélectionné' : 'Sélectionner' ?>
-                </button>
-                <input
-                  type="checkbox"
-                  name="testimonial_ids[]"
-                  value="<?= (int)$t['id'] ?>"
-                  class="sr-only testimonial-input"
-                  data-input-testimonial="<?= (int)$t['id'] ?>"
-                  <?= in_array((int)$t['id'], $linkedTestimonials, true) ? 'checked' : '' ?>
-                >
+          <section class="form-section">
+            <h3>1. Création de l’article</h3>
+            <label>Titre</label><input name="title" required value="<?= blog_h((string)($editPost['title'] ?? '')) ?>">
+            <label>Slug URL</label><input name="slug" value="<?= blog_h((string)($editPost['slug'] ?? '')) ?>">
+            <label>Extrait</label><textarea name="excerpt" rows="2" required><?= blog_h((string)($editPost['excerpt'] ?? '')) ?></textarea>
+            <label>Catégorie</label>
+            <select name="category_id" required>
+              <?php foreach ($categories as $c): ?>
+                <option value="<?= blog_h($c['id']) ?>" <?= (($editPost['category_id'] ?? '') === $c['id']) ? 'selected' : '' ?>><?= blog_h($c['name']) ?></option>
+              <?php endforeach; ?>
+            </select>
+            <label>Auteur</label>
+            <select name="author_name" required>
+              <?php foreach ($authors as $author): ?>
+                <option value="<?= blog_h($author) ?>" <?= (($editPost['author_name'] ?? '') === $author) ? 'selected' : '' ?>><?= blog_h($author) ?></option>
+              <?php endforeach; ?>
+            </select>
+            <label>Statut</label>
+            <select name="status"><option value="draft" <?= (($editPost['status'] ?? '') === 'draft') ? 'selected' : '' ?>>Brouillon</option><option value="published" <?= (($editPost['status'] ?? '') === 'published') ? 'selected' : '' ?>>Publié</option></select>
+            <label>Type de CTA</label>
+            <select name="cta_variant"><option value="contact" <?= (($editPost['cta_variant'] ?? '') === 'contact') ? 'selected' : '' ?>>Prendre contact</option><option value="visit" <?= (($editPost['cta_variant'] ?? '') === 'visit') ? 'selected' : '' ?>>Demander une visite</option></select>
+            <label>Titre SEO</label><input name="seo_title" value="<?= blog_h((string)($editPost['seo_title'] ?? '')) ?>">
+            <label>Meta description</label><textarea name="seo_description" rows="2"><?= blog_h((string)($editPost['seo_description'] ?? '')) ?></textarea>
+            <label>Contenu de l'article</label>
+            <div class="wysiwyg-wrap">
+              <div class="wysiwyg-toolbar" id="content-editor-toolbar">
+                <button type="button" data-editor-cmd="formatBlock" data-editor-value="P">Paragraphe</button>
+                <button type="button" data-editor-cmd="formatBlock" data-editor-value="H2">H2</button>
+                <button type="button" data-editor-cmd="formatBlock" data-editor-value="H3">H3</button>
+                <button type="button" data-editor-cmd="bold"><strong>Gras</strong></button>
+                <button type="button" data-editor-cmd="italic"><em>Italique</em></button>
+                <button type="button" data-editor-cmd="insertUnorderedList">Liste •</button>
+                <button type="button" data-editor-cmd="insertOrderedList">Liste 1.</button>
+                <button type="button" data-editor-cmd="formatBlock" data-editor-value="BLOCKQUOTE">Citation</button>
+                <button type="button" data-editor-cmd="createLink">Lien</button>
+                <button type="button" data-editor-cmd="unlink">Retirer lien</button>
               </div>
-            <?php endforeach; ?>
-            <?php if (empty($testimonials)): ?>
-              <p class="helper">Aucun témoignage disponible.</p>
+              <div id="content-editor" class="wysiwyg-editor" contenteditable="true" data-placeholder="Rédigez votre article ici..."></div>
+            </div>
+            <textarea name="content_html" id="content-html-input" rows="10" class="sr-only"><?= blog_h((string)($editPost['content_html'] ?? '')) ?></textarea>
+            <p class="helper">Balises autorisées : p, h2, h3, ul, ol, li, strong, em, blockquote, a, br. Pour les liens, seuls les href en https, /chemin ou #ancre sont conservés.</p>
+          </section>
+
+          <section class="form-section">
+            <h3>2. Import image</h3>
+            <label>Image au-dessus du bloc Témoignage (horizontal)</label>
+            <input type="file" name="testimonial_image" accept=".jpg,.jpeg,.png,.webp" id="testimonial-image-input">
+            <p class="helper">Image horizontale recommandée (ex: 1600x900) pour un rendu optimal. Formats autorisés : JPG, JPEG, PNG, WEBP. Taille max 5 Mo. Exemple de nom SEO : colocation-senior-salon.webp</p>
+            <?php if (!empty($editPost['testimonial_image_path'])): ?>
+              <img
+                id="testimonial-image-preview"
+                src="<?= blog_h(blog_testimonial_image_url((string)$editPost['testimonial_image_path'])) ?>"
+                alt="<?= blog_h((string)($editPost['testimonial_image_alt'] ?? '')) ?>"
+                style="max-width:100%;height:140px;object-fit:cover;border-radius:10px;border:1px solid #d1d5db"
+              >
+              <label><input type="checkbox" name="remove_testimonial_image" value="1" id="remove-testimonial-image"> Supprimer l'image actuelle</label>
+            <?php else: ?>
+              <img id="testimonial-image-preview" src="" alt="" style="display:none;max-width:100%;height:140px;object-fit:cover;border-radius:10px;border:1px solid #d1d5db">
             <?php endif; ?>
+
+            <label>Texte alternatif de l’image (obligatoire si image)</label>
+            <input
+              name="testimonial_image_alt"
+              value="<?= blog_h((string)($editPost['testimonial_image_alt'] ?? '')) ?>"
+              placeholder="Ex : Résidents lisant dans le salon de la colocation senior à Lyon"
+            >
+            <p class="helper">Alt descriptif recommandé (10 à 90 caractères), cohérent avec le sujet de l’article. Évitez les formulations génériques comme “photo proposée”.</p>
+          </section>
+
+          <section class="form-section">
+            <h3>3. Témoignages liés</h3>
+            <div class="testi-tools">
+              <input type="search" id="testimonial-search" class="testi-search" placeholder="Rechercher par nom ou ID...">
+              <button class="btn alt" type="button" id="clear-testimonials">Tout désélectionner</button>
+            </div>
+            <p class="helper">Sélectionnez un ou plusieurs témoignages. Laissez vide si vous ne souhaitez en lier aucun.</p>
+            <div class="testi-selected" id="testimonial-selected"></div>
+            <div class="testi-results" id="testimonial-results">
+              <?php foreach ($testimonials as $t): ?>
+                <div
+                  class="testi-row"
+                  data-testid="<?= (int)$t['id'] ?>"
+                  data-testi-label="<?= blog_h(mb_strtolower((string)$t['person_name'])) ?>"
+                >
+                  <span>#<?= (int)$t['id'] ?> - <?= blog_h($t['person_name']) ?> (<?= blog_h($t['status']) ?>)</span>
+                  <button type="button" data-toggle-testimonial="<?= (int)$t['id'] ?>" class="<?= in_array((int)$t['id'], $linkedTestimonials, true) ? 'active' : '' ?>">
+                    <?= in_array((int)$t['id'], $linkedTestimonials, true) ? 'Sélectionné' : 'Sélectionner' ?>
+                  </button>
+                  <input
+                    type="checkbox"
+                    name="testimonial_ids[]"
+                    value="<?= (int)$t['id'] ?>"
+                    class="sr-only testimonial-input"
+                    data-input-testimonial="<?= (int)$t['id'] ?>"
+                    <?= in_array((int)$t['id'], $linkedTestimonials, true) ? 'checked' : '' ?>
+                  >
+                </div>
+              <?php endforeach; ?>
+              <?php if (empty($testimonials)): ?>
+                <p class="helper">Aucun témoignage disponible.</p>
+              <?php endif; ?>
+            </div>
+          </section>
+
+          <div class="form-footer">
+            <button class="btn" type="submit">Enregistrer l'article</button>
           </div>
-          <button class="btn" type="submit">Enregistrer l'article</button>
         </form>
       </section>
     <?php endif; ?>
@@ -550,6 +653,7 @@ if (isset($_GET['edit_post'])) {
         <form method="post" class="stack">
           <input type="hidden" name="tab" value="create-testimonial">
           <input type="hidden" name="action" value="save_testimonial">
+          <input type="hidden" name="csrf_token" value="<?= blog_h(blog_csrf_token()) ?>">
           <input type="hidden" name="testimonial_id" value="0">
           <label>Texte du témoignage</label><textarea name="quote_text" rows="4" required></textarea>
           <label>Nom affiché (anonyme ou prénom)</label><input name="person_name" required>
@@ -564,7 +668,20 @@ if (isset($_GET['edit_post'])) {
           <thead><tr><th>Nom</th><th>Statut</th><th>Autorisation</th><th></th></tr></thead>
           <tbody>
             <?php foreach ($testimonials as $t): ?>
-              <tr><td><?= blog_h($t['person_name']) ?></td><td><?= blog_h($t['status']) ?></td><td><?= (int)$t['consent_publication'] === 1 ? 'Oui' : 'Non' ?></td><td><a href="?tab=create-testimonial&delete_testimonial=<?= (int)$t['id'] ?>" onclick="return confirm('Supprimer ce témoignage ?')">Supprimer</a></td></tr>
+              <tr>
+                <td><?= blog_h($t['person_name']) ?></td>
+                <td><?= blog_h($t['status']) ?></td>
+                <td><?= (int)$t['consent_publication'] === 1 ? 'Oui' : 'Non' ?></td>
+                <td>
+                  <form method="post" style="display:inline">
+                    <input type="hidden" name="tab" value="create-testimonial">
+                    <input type="hidden" name="action" value="delete_testimonial">
+                    <input type="hidden" name="delete_testimonial" value="<?= (int)$t['id'] ?>">
+                    <input type="hidden" name="csrf_token" value="<?= blog_h(blog_csrf_token()) ?>">
+                    <button class="btn linklike" type="submit" onclick="return confirm('Supprimer ce témoignage ?')">Supprimer</button>
+                  </form>
+                </td>
+              </tr>
             <?php endforeach; ?>
           </tbody>
         </table>
@@ -577,6 +694,7 @@ if (isset($_GET['edit_post'])) {
         <form method="post" class="stack">
           <input type="hidden" name="tab" value="create-category">
           <input type="hidden" name="action" value="save_category">
+          <input type="hidden" name="csrf_token" value="<?= blog_h(blog_csrf_token()) ?>">
           <label>ID (slug)</label><input name="id" required placeholder="conseils-aux-familles">
           <label>Nom</label><input name="name" required>
           <label>Description</label><textarea name="description" rows="2"></textarea>
@@ -597,6 +715,64 @@ if (isset($_GET['edit_post'])) {
 </div>
 <script>
   document.addEventListener('DOMContentLoaded', function () {
+    var contentInput = document.getElementById('content-html-input');
+    var contentEditor = document.getElementById('content-editor');
+    var contentToolbar = document.getElementById('content-editor-toolbar');
+    var postForm = contentInput ? contentInput.closest('form') : null;
+
+    function isAllowedEditorHref(href) {
+      if (!href) return false;
+      var value = href.trim();
+      if (!value) return false;
+      if (value.indexOf('/') === 0 || value.indexOf('#') === 0) return true;
+      return /^https:\/\/\S+$/i.test(value);
+    }
+
+    if (contentInput && contentEditor) {
+      contentEditor.innerHTML = contentInput.value || '';
+      if ((contentEditor.textContent || '').trim() === '' && contentEditor.innerHTML.trim() === '') {
+        contentEditor.innerHTML = '<p></p>';
+      }
+
+      contentToolbar?.addEventListener('click', function (event) {
+        var target = event.target;
+        if (!(target instanceof HTMLElement)) return;
+        var button = target.closest('button[data-editor-cmd]');
+        if (!(button instanceof HTMLButtonElement)) return;
+
+        var cmd = button.getAttribute('data-editor-cmd');
+        if (!cmd) return;
+
+        contentEditor.focus();
+
+        if (cmd === 'createLink') {
+          var href = window.prompt('Entrez une URL (https://...), /chemin ou #ancre :', 'https://');
+          if (!href) return;
+          if (!isAllowedEditorHref(href)) {
+            window.alert('Lien refusé : utilisez https://..., /chemin ou #ancre.');
+            return;
+          }
+          document.execCommand('createLink', false, href.trim());
+          return;
+        }
+
+        var value = button.getAttribute('data-editor-value');
+        document.execCommand(cmd, false, value || null);
+      });
+
+      if (postForm) {
+        postForm.addEventListener('submit', function (event) {
+          contentInput.value = (contentEditor.innerHTML || '').trim();
+          var editorText = (contentEditor.textContent || '').replace(/\u00A0/g, ' ').trim();
+          if (!editorText) {
+            event.preventDefault();
+            window.alert('Veuillez remplir le contenu de l’article.');
+            contentEditor.focus();
+          }
+        });
+      }
+    }
+
     var clearButton = document.getElementById('clear-testimonials');
     var imageInput = document.getElementById('testimonial-image-input');
     var imagePreview = document.getElementById('testimonial-image-preview');

--- a/admin/le-mag/logout.php
+++ b/admin/le-mag/logout.php
@@ -1,5 +1,13 @@
 <?php
 require_once __DIR__ . '/../../blog-lib/auth.php';
+
+blog_start_session();
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST' || !blog_csrf_validate_request('logout')) {
+    $_SESSION['melina_logout_error'] = BLOG_CSRF_ERROR_MESSAGE;
+    header('Location: /admin/le-mag/index.php');
+    exit;
+}
+
 blog_logout();
 header('Location: /admin/le-mag/index.php');
 exit;

--- a/blog-lib/auth.php
+++ b/blog-lib/auth.php
@@ -6,6 +6,10 @@ require_once __DIR__ . '/db.php';
 
 const BLOG_ADMIN_SESSION_KEY = 'melina_admin';
 const BLOG_SESSION_NAME = 'melina_admin_session';
+const BLOG_CSRF_TOKEN_KEY = 'blog_csrf_token';
+const BLOG_CSRF_ISSUED_AT_KEY = 'blog_csrf_issued_at';
+const BLOG_CSRF_TTL_SECONDS = 7200;
+const BLOG_CSRF_ERROR_MESSAGE = 'Session expirée, merci de recharger la page.';
 
 function blog_start_session(): void
 {
@@ -88,4 +92,59 @@ function blog_logout(): void
     }
 
     session_destroy();
+}
+
+function blog_log_security_event(string $event, array $context = []): void
+{
+    $logDir = dirname(__DIR__) . '/logs';
+    if (!is_dir($logDir)) {
+        @mkdir($logDir, 0775, true);
+    }
+
+    $logFile = $logDir . '/security.log';
+    $payload = [
+        'time' => gmdate('c'),
+        'event' => $event,
+        'ip' => (string) ($_SERVER['REMOTE_ADDR'] ?? ''),
+        'ua' => (string) ($_SERVER['HTTP_USER_AGENT'] ?? ''),
+        'context' => $context,
+    ];
+
+    @file_put_contents($logFile, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . PHP_EOL, FILE_APPEND | LOCK_EX);
+}
+
+function blog_csrf_token(): string
+{
+    blog_start_session();
+
+    $token = (string) ($_SESSION[BLOG_CSRF_TOKEN_KEY] ?? '');
+    $issuedAt = (int) ($_SESSION[BLOG_CSRF_ISSUED_AT_KEY] ?? 0);
+    $isExpired = $issuedAt <= 0 || (time() - $issuedAt) >= BLOG_CSRF_TTL_SECONDS;
+
+    if ($token === '' || $isExpired) {
+        $token = bin2hex(random_bytes(32));
+        $_SESSION[BLOG_CSRF_TOKEN_KEY] = $token;
+        $_SESSION[BLOG_CSRF_ISSUED_AT_KEY] = time();
+    }
+
+    return $token;
+}
+
+function blog_csrf_validate_request(string $action): bool
+{
+    blog_start_session();
+    blog_csrf_token();
+
+    $candidate = (string) ($_POST['csrf_token'] ?? '');
+    $sessionToken = (string) ($_SESSION[BLOG_CSRF_TOKEN_KEY] ?? '');
+    if ($candidate === '' || $sessionToken === '' || !hash_equals($sessionToken, $candidate)) {
+        blog_log_security_event('csrf_validation_failed', [
+            'action' => $action,
+            'method' => (string) ($_SERVER['REQUEST_METHOD'] ?? ''),
+            'uri' => (string) ($_SERVER['REQUEST_URI'] ?? ''),
+        ]);
+        return false;
+    }
+
+    return true;
 }

--- a/blog-lib/utils.php
+++ b/blog-lib/utils.php
@@ -54,3 +54,132 @@ function blog_fetch_categories(): array
     $stmt = blog_pdo()->query('SELECT id, name, description, sort_order FROM blog_categories ORDER BY sort_order ASC, name ASC');
     return $stmt->fetchAll();
 }
+
+function blog_is_allowed_href(string $href): bool
+{
+    $href = trim($href);
+    if ($href === '') {
+        return false;
+    }
+
+    if (str_starts_with($href, '/')) {
+        return true;
+    }
+
+    if (str_starts_with($href, '#')) {
+        return true;
+    }
+
+    return preg_match('/^https:\/\/[^\s]+$/iu', $href) === 1;
+}
+
+function blog_sanitize_content_html(string $html, ?bool &$wasModified = null): string
+{
+    $allowedTags = ['p', 'h2', 'h3', 'ul', 'ol', 'li', 'strong', 'em', 'blockquote', 'a', 'br'];
+    $wasModified = false;
+
+    $wrappedHtml = '<div id="blog-sanitizer-root">' . $html . '</div>';
+
+    libxml_use_internal_errors(true);
+    $dom = new DOMDocument('1.0', 'UTF-8');
+    $loaded = $dom->loadHTML(
+        '<?xml encoding="UTF-8">' . $wrappedHtml,
+        LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+    );
+    libxml_clear_errors();
+
+    if (!$loaded) {
+        $wasModified = true;
+        return '';
+    }
+
+    $xpath = new DOMXPath($dom);
+    $root = $xpath->query('//*[@id="blog-sanitizer-root"]')->item(0);
+    if (!$root instanceof DOMElement) {
+        $wasModified = true;
+        return '';
+    }
+
+    $sanitizeNode = static function (DOMNode $node) use (&$sanitizeNode, $dom, $allowedTags, &$wasModified): void {
+        if ($node instanceof DOMElement) {
+            $tagName = strtolower($node->tagName);
+
+            if (!in_array($tagName, $allowedTags, true)) {
+                $wasModified = true;
+
+                if (in_array($tagName, ['script', 'style', 'iframe'], true)) {
+                    $node->parentNode?->removeChild($node);
+                    return;
+                }
+
+                while ($node->firstChild) {
+                    $node->parentNode?->insertBefore($node->firstChild, $node);
+                }
+                $node->parentNode?->removeChild($node);
+                return;
+            }
+
+            $allowedAttributes = $tagName === 'a' ? ['href', 'target', 'rel'] : [];
+            $attributes = [];
+            foreach ($node->attributes ?? [] as $attribute) {
+                $attributes[] = $attribute;
+            }
+
+            foreach ($attributes as $attribute) {
+                $name = strtolower($attribute->name);
+                if (!in_array($name, $allowedAttributes, true)) {
+                    $node->removeAttributeNode($attribute);
+                    $wasModified = true;
+                }
+            }
+
+            if ($tagName === 'a') {
+                $href = (string) $node->getAttribute('href');
+                if (!blog_is_allowed_href($href)) {
+                    while ($node->firstChild) {
+                        $node->parentNode?->insertBefore($node->firstChild, $node);
+                    }
+                    $node->parentNode?->removeChild($node);
+                    $wasModified = true;
+                    return;
+                }
+
+                $target = strtolower((string) $node->getAttribute('target'));
+                if ($target !== '_blank') {
+                    if ($target !== '') {
+                        $wasModified = true;
+                    }
+                    $node->removeAttribute('target');
+                    $node->removeAttribute('rel');
+                } else {
+                    $node->setAttribute('target', '_blank');
+                    $node->setAttribute('rel', 'noopener noreferrer');
+                }
+            }
+        }
+
+        $children = [];
+        foreach ($node->childNodes as $child) {
+            $children[] = $child;
+        }
+
+        foreach ($children as $child) {
+            $sanitizeNode($child);
+        }
+    };
+
+    $rootChildren = [];
+    foreach ($root->childNodes as $child) {
+        $rootChildren[] = $child;
+    }
+    foreach ($rootChildren as $child) {
+        $sanitizeNode($child);
+    }
+
+    $result = '';
+    foreach ($root->childNodes as $child) {
+        $result .= $dom->saveHTML($child);
+    }
+
+    return trim($result);
+}

--- a/le-mag/article.php
+++ b/le-mag/article.php
@@ -37,6 +37,7 @@ try {
 }
 
 $cta = blog_cta_data($post['cta_variant'] ?? 'contact');
+$safeContentHtml = blog_sanitize_content_html((string) ($post['content_html'] ?? ''));
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -117,7 +118,7 @@ $cta = blog_cta_data($post['cta_variant'] ?? 'contact');
     <p><?= blog_h($post['category_name']) ?></p>
     <h1><?= blog_h($post['title']) ?></h1>
     <p class="meta"><?= blog_h(date('d/m/Y', strtotime((string)$post['published_at']))) ?> · <?= blog_h($post['author_name']) ?></p>
-    <div class="content"><?= $post['content_html'] ?></div>
+    <div class="content"><?= $safeContentHtml ?></div>
   </article>
 
   <?php if (!empty($post['testimonial_image_path'])): ?>


### PR DESCRIPTION
### Motivation

- Prevent CSRF on admin actions and logout by introducing server-side token checks and switching destructive links to POST forms.
- Protect site visitors from unsafe HTML injected in articles by sanitizing stored/presented content and validating editor links.
- Improve editor UX for content authors by adding a simple WYSIWYG toolbar and client-side validation for links.
- Make failure modes more diagnosable by logging security/DB errors and returning clearer user-facing messages.

### Description

- Added CSRF support with `blog_csrf_token()` and `blog_csrf_validate_request()` and constants including `BLOG_CSRF_TTL_SECONDS`, and wired validation into admin flows and `logout.php` requiring POST with a token. 
- Replaced GET-based delete links with POST forms containing `csrf_token` for `delete_post` and `delete_testimonial`, and added hidden `csrf_token` inputs to all admin forms and the logout button.
- Implemented `blog_log_security_event()` to append JSON security logs to `logs/security.log` and used it to record failed CSRF checks and detailed SQL errors during post/testimonial save attempts.
- Added content sanitization utilities `blog_sanitize_content_html()` and `blog_is_allowed_href()` in `blog-lib/utils.php`, applied sanitization when saving posts and when rendering `le-mag/article.php`, and surface a notice to the editor when content was modified for safety via `$editorNotice`.
- Introduced a basic WYSIWYG editor in the admin UI with toolbar buttons and client-side link validation that only allows `https://`, root-path (`/...`) or anchor (`#...`) hrefs, and made the editor synchronize to the hidden `content_html` textarea on submit.
- Hardened SQL error handling when saving posts to map SQLSTATEs like `23000` and `22001` to friendlier messages (duplicate slug, missing category, or too-long fields) and logged context for diagnostics.
- UI and CSS tweaks: reorganized the post form into `form-section` blocks, added helper copy, preview behavior, and small styling for link-like buttons.

### Testing

- Ran PHP syntax checks on modified files using `php -l` and fixed issues; the syntax checks passed.
- No automated unit tests for these features were available in the repository, so no additional CI/unit tests were executed. Please consider adding unit/integration tests for CSRF, sanitizer and SQL error mappings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db78a1d74883329d326fbded30e663)