### PR TITLE
Standardize wording to “colocations seniors” across site

### DIFF
--- a/concept/index.html
+++ b/concept/index.html
@@ -187,7 +187,7 @@
               <div class="text-content" data-astro-cid-5tomgpma>
                 <div class="section-title" data-astro-cid-5tomgpma>
                   <h2 data-astro-cid-5tomgpma>
-                    Qu'est-ce qu'une maison partagée ?
+                    Qu'est-ce qu'une colocation seniors ?
                   </h2>
                 </div>
                 <div class="content-box" data-astro-cid-5tomgpma>

--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
               </h1>
               <p class="tagline" data-astro-cid-j7pv25f6>
                 <strong data-astro-cid-j7pv25f6>
-                  Les maisons partagées séniors
+                  Colocations Seniors
                 </strong>
               </p>
               <p class="subtitle" data-astro-cid-j7pv25f6>
@@ -300,7 +300,7 @@
           <section class="features" data-astro-cid-j7pv25f6>
             <div class="features-header" data-astro-cid-j7pv25f6>
               <h2 data-astro-cid-j7pv25f6>
-                Les principaux atouts de nos maisons partagées
+                Les principaux atouts de nos colocations seniors
               </h2>
               <p class="lead" data-astro-cid-j7pv25f6>
                 Une solution innovante et protectrice pour les seniors autonomes

--- a/nos-maisons/index.html
+++ b/nos-maisons/index.html
@@ -483,7 +483,7 @@
       <div class="main-content" data-astro-cid-sckkx6r4>
         <main data-astro-cid-zn4jaifo>
           <div class="hero-section" data-astro-cid-zn4jaifo>
-            <h1 data-astro-cid-zn4jaifo>Nos Maisons Partagées</h1>
+            <h1 data-astro-cid-zn4jaifo>Nos colocations seniors</h1>
             <p class="lead" data-astro-cid-zn4jaifo>
               Découvrez nos maisons disponibles et trouvez votre futur chez-vous
             </p>


### PR DESCRIPTION
### Motivation
- Standardize the public-facing terminology by replacing references to "maison(s) partagée(s)" with "colocation(s) seniors" for clearer messaging and improved consistency across pages.
- Align hero text and section headings to better target the intended audience and SEO keywords.

### Description
- Updated wording in `concept/index.html`, `index.html`, and `nos-maisons/index.html` to use "colocation(s) seniors" in headings, hero taglines, and feature titles.
- Adjusted specific phrases such as `Qu'est-ce qu'une maison partagée ?` -> `Qu'est-ce qu'une colocation seniors ?` and `Les maisons partagées` -> `Les colocations seniors` where applicable.
- Preserved existing markup and scripts and applied a minor end-of-file newline normalization in the modified HTML files.

### Testing
- No automated tests were run for this copy/text change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e93d80688332a4c07f94baafbbd0)